### PR TITLE
Fixed current texture string bug

### DIFF
--- a/Source/MaterialEditor.cpp
+++ b/Source/MaterialEditor.cpp
@@ -27,6 +27,7 @@ void MaterialEditor::Draw()
 		if (!ImGui::IsPopupOpen(materialPopup))
 		{
 			ImGui::OpenPopup(materialPopup);
+			SetCurrentTextures();
 			if (isCreated)
 			{
 				material = new Material();
@@ -172,6 +173,22 @@ void MaterialEditor::TextureSelector(unsigned i, std::string &current_texture)
 		ImGui::Image((ImTextureID)material->textures[i]->id, { 200,200 }, { 0,1 }, { 1,0 });
 	}
 }
+
+void MaterialEditor::SetCurrentTextures()
+{
+	// Get material textures
+	Texture* diffuse_texture = material->GetTexture(TextureType::DIFFUSE);
+	Texture* specular_texture = material->GetTexture(TextureType::SPECULAR);
+	Texture* occlusion_texture = material->GetTexture(TextureType::OCCLUSION);
+	Texture* emissive_texture = material->GetTexture(TextureType::EMISSIVE);
+
+	// Set current textures strings
+	if (diffuse_texture != nullptr)		{ current_diffuse = diffuse_texture->file; }
+	if (specular_texture != nullptr)	{ current_specular = specular_texture->file; }
+	if (occlusion_texture != nullptr)	{ current_occlusion = occlusion_texture->file; }
+	if (emissive_texture != nullptr)	{ current_emissive = emissive_texture->file; }
+}
+
 void MaterialEditor::CleanUp()
 {
 	if (isCreated) RELEASE(material);

--- a/Source/MaterialEditor.h
+++ b/Source/MaterialEditor.h
@@ -13,10 +13,11 @@ public:
 	void Draw();
 	void ShaderSelector(std::string &current_shader);
 	void TextureSelector(unsigned i, std::string &current_texture);
+	void SetCurrentTextures();	// Sets current textures strings with the corresponding texture file string
 	void CleanUp();
 
 public:
-	bool open=false;
+	bool open = false;
 	bool isCreated = false;
 	Material* material = nullptr;
 	Material* previous = nullptr;


### PR DESCRIPTION
On material editor: It now shows the selected texture file string instead of the default "None Selected". Only if it has a texture assigned.